### PR TITLE
AddParameter from anywhere in a method

### DIFF
--- a/plugin/ruby-refactoring.vim
+++ b/plugin/ruby-refactoring.vim
@@ -30,6 +30,15 @@ function! AddParameter()
     return
   endtry
 
+  " Save current position
+  let cursor_position = getpos(".")
+
+  " Move backwards to the method definiton if you are not already on the
+  " correct line
+  if empty(matchstr(getline("."), '\<def\>'))
+    exec "?\\<def\\>"
+  endif
+
   let closing_bracket_index = stridx(getline("."), ")")
 
   if closing_bracket_index == -1
@@ -37,6 +46,9 @@ function! AddParameter()
   else
     exec ':.s/)/, ' . name . ')/'
   endif
+
+  " Restore caret position
+  call setpos(".", cursor_position)
 endfunction
 
 " Synopsis


### PR DESCRIPTION
I have modified AddParameter to allow you to add parameters to the current method from any line inside of the method.  Without this patch your cursor must be on the first line of the method. The user's previous cursor position is restored after the parameter is added.  Not a huge change, but it feels more natural to me if AddParameter behaves in this way.  
