### PR TITLE
Added cucumber scenario for inlineTemp issue

### DIFF
--- a/features/inline_temp.feature
+++ b/features/inline_temp.feature
@@ -108,3 +108,19 @@ Feature: Inline Temp :RInlineTemp
     c = 2 + 1
 
     """
+
+  @issues
+  Scenario: Inline a temporary variable to a value within a string
+    Given I have the following code:
+    """
+    then = 2006
+    word  = "#{then}-01-01"
+    """
+    When I go to the line and execute:
+    """
+    :RInlineTemp
+    """
+    Then I should see:
+    """
+    word  = "2006-01-01"
+    """


### PR DESCRIPTION
Cucumber result:

expected: "word  = \"2006-01-01\""
           got: "word  = \"#{2006}-01-01\"\n" (using ==)
