### PR TITLE
Replace all local instances in ExtractLocalVariable

### DIFF
--- a/features/extract_local_variable.feature
+++ b/features/extract_local_variable.feature
@@ -29,3 +29,30 @@ Feature: Extract Local Variable :RExtractLocalVariable
     end
     
     """
+
+    Scenario: Extract a local variable from a magic string with multiple references
+    Given I have the following code:
+    """
+    class Foo
+      def bar
+        some_func_call("some magic string")
+        some_var = "some magic string"
+      end
+    end
+    """
+    When I select "some magic string" and execute:
+    """
+    :RExtractLocalVariable"
+    """
+    And I fill in the parameter "local_variable"
+    Then I should see:
+    """
+    class Foo
+      def bar
+        local_variable = "some magic string"
+        some_func_call(local_variable)
+        some_var = local_variable
+      end
+    end
+    
+    """

--- a/features/step_definitions/extract_local_variable_steps.rb
+++ b/features/step_definitions/extract_local_variable_steps.rb
@@ -1,0 +1,10 @@
+When /^I select \"some magic string\" and execute:$/ do |command|
+  select_magic_string
+  add_to_commands command
+end
+
+def select_magic_string
+  @commands = ':normal 3Gf"va"'
+  add_return_key
+end
+

--- a/plugin/refactorings/general/extractvariable.vim
+++ b/plugin/refactorings/general/extractvariable.vim
@@ -1,22 +1,23 @@
 " Synopsis:
 "   Extracts the selected scope to a variable
 function! ExtractLocalVariable()
+  let selection = common#get_visual_selection()
+
   try
     let name = common#get_input("Variable name: ", "No variable name given!")
   catch
     echo v:exception
     return
   endtry
-  " Enter visual mode (not sure why this is needed since we're already in
-  " visual mode anyway)
-  normal! gv
 
-  " Replace selected text with the variable name
-  exec "normal c" . name
+  " Find the start and end of the current block
+  let [block_start, block_end] = common#get_range_for_block('\<def\>','Wb')
+
+  " Use the variable in all occurences within the block
+  call common#gsub_all_in_range(block_start, block_end, '[^@]\zs'.selection.'\ze\([^\(]\|$\)', name)
+
   " Define the variable on the line above
-  exec "normal! O" . name . " = "
-  " Paste the original selected text to be the variable value
-  normal! $p
+  exec "normal! O" . name . " = " . selection
 endfunction
 
 


### PR DESCRIPTION
Often I end up with duplicate instances of a value that I want to extract into a local variable. This is my attempt at replacing all of them.

Currently it only replaces values within the block to ensure scoping is ok. Also, you must perform the operation on the first instance of the text to be extracted.
