### PR TITLE
Fix regex for "Extract Let"

### DIFF
--- a/plugin/refactorings/general/rspec_extractlet.vim
+++ b/plugin/refactorings/general/rspec_extractlet.vim
@@ -8,7 +8,7 @@ function! ExtractIntoRspecLet()
     return
   end
   normal! dd
-  exec "?^\\<describe\\|context\\>"
+  exec "?^\\s*\\<\\(describe\\|context\\)\\>"
   normal! $p
   exec 's/\v([a-z_][a-zA-Z0-9_]*) \= (.+)/let(:\1) { \2 }'
   normal V=


### PR DESCRIPTION
fix some regex bug.
- 'describe'  with white space is beggining
- 'context' is end of line
