### PR TITLE
Added pre/post-conditional toggle

### DIFF
--- a/features/post_conditional.feature
+++ b/features/post_conditional.feature
@@ -1,10 +1,11 @@
 Feature: Convert Post Conditional :RConvertPostConditional
-  Takes a post-conditional expression and converts it into a regular conditional statement
+  Takes a post-conditional expression and converts it into a regular conditional statement (and vice versa)
 
     Shortcuts:
       :RConvertPostConditional
       <leader>rcpc
 
+  @issue
   Scenario: Convert a simple if post-conditional expression
     Given I have the following code:
     """
@@ -17,7 +18,22 @@ Feature: Convert Post Conditional :RConvertPostConditional
     Then I should see:
     """
     if condition
-      do_something 
+      do_something
     end
+    """
 
+  Scenario: Convert a simple if pre-conditional expression
+    Given I have the following code:
+    """
+    if condition
+      do_something
+    end
+    """
+    When I go to the line and execute:
+    """
+    :RConvertPostConditional
+    """
+    Then I should see:
+    """
+    do_something if condition
     """

--- a/plugin/refactorings/general/postconditional.vim
+++ b/plugin/refactorings/general/postconditional.vim
@@ -13,27 +13,58 @@ function! ConvertPostConditional()
 
   " if the first match isn't on the current line, exit.
   if current_line != first_match
+    "echo "no match"
     return
   endif
 
-  " move the cursor to the first found conditional operator
+  " move the cursor *backward* to the first found conditional operator
   call search(conditional_operators, 'bW')
-  " save original value of buffer a into temp variable
-  let original_value = @a
-  " delete to the end of the line into buffer a
-  normal "ad$
-  " insert new line above
-  normal O
-  " and paste buffer a
-  normal "ap
-  " indent conditional properly
-  normal ==
-  " restore original value back to register a
-  let @a = original_value
-  " move one line down and add 'end'
-  exec "normal jo" . "end"
-  " move back to the line that you started at
-  normal k
-  " indent the conditional body
-  normal >>
+  let conditional_pos = col(".")
+
+  " move the cursor to the first word char on the line
+  normal ^
+  let line_start_pos = col(".")
+
+  " move the cursor *forward* to the first found conditional operator
+  call search(conditional_operators, 'cW')
+
+  " if conditional starts line (pre-conditional), convert *to* post-conditional
+  let is_pre_conditional = line_start_pos == conditional_pos
+  if is_pre_conditional
+    " convert to post-conditional (e.g. do_stuff() if condition)
+
+    " assert conditional statement takes exactly three lines
+    let first_line = line('.')
+    let last_line = search('^\s*end\s*$', 'nW')
+    let is_three_lines = (last_line - first_line) == 2
+    if is_three_lines
+      " delete third line, cut first, paste after second, join, indent properly
+      normal jjddkkddpkJ==
+    else
+      "echo "multi-line conditional contains 2+ statements, aborting"
+    endif
+  else
+    " convert to pre-conditional (e.g. if condition \n do_stuff() \n end)
+
+    " save original value of buffer a into temp variable
+    let original_value = @a
+    " delete to the end of the line into buffer a
+    normal "ad$
+    " insert new line above
+    normal O
+    " and paste buffer a
+    normal "ap
+    " indent conditional properly
+    normal ==
+    " restore original value back to register a
+    let @a = original_value
+    " move one line down and add 'end'
+    exec "normal jo" . "end"
+    " move back to the line that you started at
+    normal k
+    " indent the conditional body
+    normal >>
+    " remove trailing whitespace from paste operation
+	  s/\s*$//g
+  endif
 endfunction


### PR DESCRIPTION
(Pardon the silly markdown formatting)

Added pre/post-conditional toggle and removed stray whitespace at end of statement. (Fails cucumber tests, but test failed before my change. Line ending mismatch or other test shortcoming.)

The original RConvertPostConditional was leaving an undesired space at the end of the statement:

  if condition
    do_something<space>
  end

  That space is now gone from the function and from the corresponding Cucumber test expectation.

Now, when the RConvertPostConditional command is executed (on the line containing the "if") on a pre-conditional expression, the expression will be converted to post-conditional style. Thus, we can toggle between conditional styles. If the block ("do_something") contains more than one line, it will not be toggled.

  if condition
    do_something
  end
  # to: do_something if condition

I created a new test, however both fail for me. I hate to send a pull request for failing tests, but I think they might pass for you. The existing test (post-to-pre) failed for me before I altered the code and the new test (pre-to-post) might have failed due to the VimBot cursor being on the wrong line but I'm not sure. My results follow. If you get the same failing results, then I can take a further look.

---

rake
/home/toby/.rvm/rubies/ruby-1.9.2-p180/bin/ruby -S bundle exec cucumber 
Using the default profile...
......................................................................F..F........

(::) failed steps (::)

expected: "if condition\n  do_something\nend"
     got: "if condition\r  do_something\rend\r" (using ==)
Diff:
@@ -1,4 +1,2 @@
-if condition
-  do_something
  -end
  endo_something
  (RSpec::Expectations::ExpectationNotMetError)
  ./features/step_definitions/shared_steps.rb:10:in `/^I should see:$/'
  features/post_conditional.feature:18:in`Then I should see:'

expected: "do_something if condition"
     got: "if condition\n  do_something\n" (using ==)
Diff:
@@ -1,2 +1,3 @@
-do_something if condition
+if condition
-  do_something
  (RSpec::Expectations::ExpectationNotMetError)
  ./features/step_definitions/shared_steps.rb:10:in `/^I should see:$/'
  features/post_conditional.feature:36:in`Then I should see:'

Failing Scenarios:
cucumber features/post_conditional.feature:9 # Scenario: Convert a simple if post-conditional expression
cucumber features/post_conditional.feature:25 # Scenario: Convert a simple if pre-conditional expression

23 scenarios (2 failed, 21 passed)
82 steps (2 failed, 80 passed)
0m11.332s
