### PR TITLE
Ignore generated doc tags for pathogen users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.un~
 *.swp
+doc/tags


### PR DESCRIPTION
I keep my vim configs in a git repo and use pathogen to load vim-ruby-refactoring. But once vim has generated doc/tags in vim-ruby-refactoring/plugin, git status in my repo complains about uncommitted changes in the submodule.

Would you consider adding doc/tags to your .gitignore so that your repo works nicely as a submodule?
