### PR TITLE
Let user disable default mappings

### DIFF
--- a/doc/rubyrefactoring.txt
+++ b/doc/rubyrefactoring.txt
@@ -56,6 +56,11 @@ Default bindings:
 :vnoremap <leader>rriv :RRenameInstanceVariable<cr>
 :vnoremap <leader>rem  :RExtractMethod<cr>
 
+Disable default bindings with:
+>
+    let g:ruby_refactoring_map_keys=0
+<
+
 ADDITIONAL USAGE EXAMPLES                   *rubyrefactoring-usageexamples*
 
 http://justinram.wordpress.com/2010/12/30/vim-ruby-refactoring-series/

--- a/plugin/ruby-refactoring.vim
+++ b/plugin/ruby-refactoring.vim
@@ -38,16 +38,21 @@ command! -range RExtractMethod          call ExtractMethod()
 " Default mappings are <leader>r followed by an acronym of the pattern's name
 " E.g. Extract Method is mapped to <leader>rem
 
-nnoremap <leader>rap  :RAddParameter<cr>
-nnoremap <leader>rapn :RAddParameterNB<cr>
-nnoremap <leader>rit  :RInlineTemp<cr>
-nnoremap <leader>rel  :RExtractLet<cr>
-nnoremap <leader>rcpc :RConvertPostConditional<cr>
-nnoremap <leader>riv  :RIntroduceVariable<cr>
+if !exists('g:ruby_refactoring_map_keys')
+  let g:ruby_refactoring_map_keys = 1
+endif
 
-vnoremap <leader>rec  :RExtractConstant<cr>
-vnoremap <leader>relv :RExtractLocalVariable<cr>
-vnoremap <leader>rrlv :RRenameLocalVariable<cr>
-vnoremap <leader>rriv :RRenameInstanceVariable<cr>
-vnoremap <leader>rem  :RExtractMethod<cr>
+if g:ruby_refactoring_map_keys
+  nnoremap <leader>rap  :RAddParameter<cr>
+  nnoremap <leader>rapn :RAddParameterNB<cr>
+  nnoremap <leader>rit  :RInlineTemp<cr>
+  nnoremap <leader>rel  :RExtractLet<cr>
+  nnoremap <leader>rcpc :RConvertPostConditional<cr>
+  nnoremap <leader>riv  :RIntroduceVariable<cr>
 
+  vnoremap <leader>rec  :RExtractConstant<cr>
+  vnoremap <leader>relv :RExtractLocalVariable<cr>
+  vnoremap <leader>rrlv :RRenameLocalVariable<cr>
+  vnoremap <leader>rriv :RRenameInstanceVariable<cr>
+  vnoremap <leader>rem  :RExtractMethod<cr>
+endif


### PR DESCRIPTION
Provide the g:ruby_refactoring_map_keys configuration option that allows
user decide whether ruby-refactoring should set key bindings. Enabled by
default.
