### PR TITLE
When extracting to a 'let', the equals sign can have zero or more spaces around it

### DIFF
--- a/plugin/refactorings/general/rspec_extractlet.vim
+++ b/plugin/refactorings/general/rspec_extractlet.vim
@@ -10,7 +10,7 @@ function! ExtractIntoRspecLet()
   normal! dd
   exec "?^\\s*\\<\\(describe\\|context\\)\\>"
   normal! $p
-  exec 's/\v([a-z_][a-zA-Z0-9_]*) \= (.+)/let(:\1) { \2 }'
+  exec 's/\v([a-z_][a-zA-Z0-9_]*)\s*\=\s*(.+)/let(:\1) { \2 }'
   normal V=
 
 endfunction


### PR DESCRIPTION
Self-explanatory.  Extracting any of these:

``` ruby
some_local_var           = :something_else
other_var=2
whatever_ya_know_you_are =   "Yep"
```

Does not work.

After this pull request, they do.
