### PR TITLE
Parenless Style on Extract, via g:ruby_refactoring_sans_superfluous_syntax

### DIFF
--- a/plugin/refactorings/general/extractmethod.vim
+++ b/plugin/refactorings/general/extractmethod.vim
@@ -240,8 +240,13 @@ function! s:em_insert_new_method(name, selection, parameters, retvals, block_end
 
   " Build new method text, split into a list for easy insertion
   let method_params = ""
-  if len(a:parameters) > 0 
-    let method_params = "(" . join(a:parameters, ", ") . ")"
+  if len(a:parameters) > 0
+    let method_params = join(a:parameters, ", ")
+    if exists('g:ruby_refactoring_sans_superfluous_syntax')
+      let method_params = ' ' . method_params
+    else
+      let method_params = "(" . method_params . ")"
+    end
   endif
 
   let method_retvals = ""


### PR DESCRIPTION
If someone does:

```
let g:ruby_refactoring_sans_superfluous_syntax = 1
```

They will now get method extractions without parens (which, technically, aren't always superfluous, but people that prefer this style can cope with those cases)
